### PR TITLE
Use CharSequence instead of String for title and subtitle

### DIFF
--- a/library/src/main/java/com/afollestad/materialcab/attached/AttachedCab.kt
+++ b/library/src/main/java/com/afollestad/materialcab/attached/AttachedCab.kt
@@ -38,13 +38,13 @@ interface AttachedCab {
   /** Sets the CAB's title. */
   fun title(
     @StringRes res: Int? = null,
-    literal: String? = null
+    literal: CharSequence? = null
   )
 
   /** Sets the CAB's subtitle. */
   fun subtitle(
     @StringRes res: Int? = null,
-    literal: String? = null
+    literal: CharSequence? = null
   )
 
   /** Sets the CAB's title text color. */

--- a/library/src/main/java/com/afollestad/materialcab/attached/RealAttachedCab.kt
+++ b/library/src/main/java/com/afollestad/materialcab/attached/RealAttachedCab.kt
@@ -39,9 +39,9 @@ import com.afollestad.materialcab.internal.drawable
 import com.afollestad.materialcab.internal.onAnimationEnd
 import com.afollestad.materialcab.internal.onLayout
 import com.afollestad.materialcab.internal.removeSelf
+import com.afollestad.materialcab.internal.requireOneCharSequence
 import com.afollestad.materialcab.internal.requireOneColor
 import com.afollestad.materialcab.internal.requireOneDimen
-import com.afollestad.materialcab.internal.requireOneString
 import com.afollestad.materialcab.internal.tint
 import com.afollestad.materialcab.invokeAll
 
@@ -91,16 +91,16 @@ class RealAttachedCab internal constructor(
 
   override fun title(
     @StringRes res: Int?,
-    literal: String?
+    literal: CharSequence?
   ) {
-    attachedToolbar.title = attachedContext.requireOneString(literal, res)
+    attachedToolbar.title = attachedContext.requireOneCharSequence(literal, res)
   }
 
   override fun subtitle(
     @StringRes res: Int?,
-    literal: String?
+    literal: CharSequence?
   ) {
-    attachedToolbar.subtitle = attachedContext.requireOneString(literal, res)
+    attachedToolbar.subtitle = attachedContext.requireOneCharSequence(literal, res)
   }
 
   override fun titleColor(

--- a/library/src/main/java/com/afollestad/materialcab/internal/Extensions.kt
+++ b/library/src/main/java/com/afollestad/materialcab/internal/Extensions.kt
@@ -91,11 +91,11 @@ internal inline fun View.onLayout(crossinline callback: (view: View) -> Unit) {
   })
 }
 
-internal fun Context.requireOneString(
-  literal: String?,
+internal fun Context.requireOneCharSequence(
+  literal: CharSequence?,
   @StringRes res: Int?,
   vararg args: Any
-): String {
+): CharSequence {
   return when {
     literal != null -> literal
     res != null -> string(res)


### PR DESCRIPTION
**Problem**:
 Using String in public API for title and subtitle makes impossible to use SpannableSting

**Solution**:
 Use CharSequence

String implements CharSequence so there is no breaking change in public APIs.

